### PR TITLE
Bump tokio dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,18 @@ repository = "https://github.com/lawliet89/aws-auth-payload"
 description = "This library provides methods for you to use your AWS credentials to generate a pre-signed request to AWS API."
 
 [dependencies]
-base64 = "0.13.0"
-failure =  { version = "0.1.3", features=["backtrace"] }
-failure_derive = "0.1.3"
-lazy_static = "1.3.0"
+base64 = "0.13"
+failure =  { version = "0.1", features=["backtrace"] }
+failure_derive = "0.1"
+lazy_static = "1.4"
 log = "0.4"
-rusoto_core = "0.46"
+rusoto_core = "0.47"
 serde = { version = "1.0", features = ["derive"] }
-serde_urlencoded = "0.7.0"
+serde_urlencoded = "0.7"
 
 [dev-dependencies]
-env_logger = "0.8.2"
-rusoto_mock = "0.46"
+env_logger = "0.9"
+rusoto_mock = "0.47"
 serde_json = "1.0"
-tokio = { version = "0.2", features=["macros", "rt-threaded"] }
-url = "2.1.0"
+tokio = { version = "1.0", features=["macros", "rt-multi-thread"] }
+url = "2.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -182,7 +182,7 @@ pub(crate) mod tests {
         Ok(presigned_url(&cred, region, header, None))
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn post_aws_iam_payload_has_expected_values() -> Result<(), crate::Error> {
         let region = Region::UsEast1;
         let headers = [("X-Vault-AWS-IAM-Server-ID", "vault.example.com")]
@@ -210,7 +210,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn presigned_url_has_expected_values() -> Result<(), crate::Error> {
         let region = Region::UsEast1;
         let headers = [("X-K8S-AWS-ID", "example")].iter().cloned().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod tests {
 
     use std::env;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn expected_aws_credentials() -> Result<(), crate::Error> {
         let access_key = "test_key";
         let secret_key = "test_secret";


### PR DESCRIPTION
Current version in `Cargo.toml` is 0.3.0 but it's not released to crates.io yet. We can do it after merging.

Drops patch versions across all libs.